### PR TITLE
Fixed YAML Error

### DIFF
--- a/zabbix-rabbitmq-plugin
+++ b/zabbix-rabbitmq-plugin
@@ -24,7 +24,7 @@ def getConfigs():
     try:
 
         stream = open("%s/config.yml" % (os.path.dirname(os.path.realpath(__file__))), "r")
-        return yaml.load(stream)
+        return yaml.load(stream, Loader=yaml.FullLoader)
 
     except Exception, e:
 


### PR DESCRIPTION
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.